### PR TITLE
Expiration of http_cache in Redis

### DIFF
--- a/HttpRedisCache.php
+++ b/HttpRedisCache.php
@@ -16,8 +16,8 @@ class HttpRedisCache extends HttpCache
 {
     public function createStore()
     {
-        return new RedisHttpStore($this->getConnectionParams(), $this->getDigestKeyPrefix(), $this->getLockKey(
-        ), $this->getMetadataKeyPrefix());
+        return new RedisHttpStore($this->getConnectionParams(), $this->getOptions(), $this->getDigestKeyPrefix(
+        ), $this->getLockKey(), $this->getMetadataKeyPrefix());
     }
 
     public function getConnectionParams()

--- a/Store/RedisHttpStore.php
+++ b/Store/RedisHttpStore.php
@@ -17,14 +17,16 @@ use Symfony\Component\HttpKernel\HttpCache\StoreInterface;
 class RedisHttpStore implements StoreInterface
 {
     protected $client;
+    protected $options;
     protected $digest_key_prefix;
     protected $metadata_key_prefix;
     protected $lock_key;
     protected $keyCache;
 
-    public function __construct($connection_params, $digest_key_prefix, $lock_key, $metadata_key_prefix)
+    public function __construct($connection_params, $options, $digest_key_prefix, $lock_key, $metadata_key_prefix)
     {
         $this->client = new Client($connection_params);
+        $this->options = $options;
         $this->digest_key_prefix = $digest_key_prefix;
         $this->lock_key = $lock_key;
         $this->metadata_key_prefix = $metadata_key_prefix;
@@ -309,7 +311,11 @@ class RedisHttpStore implements StoreInterface
     {
         $this->client->createConnection();
 
-        $this->client->set($key, $data);
+        if (isset($this->options['default_ttl']) && $this->options['default_ttl'] > 0) {
+            $this->client->setex($key, $this->options['default_ttl'], $data);
+        } else {
+            $this->client->set($key, $data);
+        }
 
         $this->client->close();
     }

--- a/Test/Store/RedisHttpStoreTest.php
+++ b/Test/Store/RedisHttpStoreTest.php
@@ -22,7 +22,13 @@ class RedisHttpStoreTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->store = new RedisHttpStore(array('host' => 'localhost'), 'hdr', 'ldr', 'mdr');
+        $this->store = new RedisHttpStore(
+            array('host' => 'localhost'),
+            array('default_ttl' => 60),
+            'hdr',
+            'ldr',
+            'mdr'
+        );
 
         $this->request = Request::create('/');
 


### PR DESCRIPTION
Added expiration for records in redis. Expirations equals to default_ttl so records with old cache will be removed automatically from redis and and will free up memory.